### PR TITLE
Apply arg defaults in one pass

### DIFF
--- a/prboom2/src/doomtype.h
+++ b/prboom2/src/doomtype.h
@@ -175,7 +175,4 @@ enum patch_translation_e {
   VPT_NOOFFSET = 1024,
 };
 
-// [XA] Common macro for defining an arg's default value if zero
-#define ARG_DEFAULT(x, y) ((x) == 0 ? (y) : (x))
-
 #endif

--- a/prboom2/src/p_enemy.c
+++ b/prboom2/src/p_enemy.c
@@ -3009,14 +3009,14 @@ void A_SpawnObject(mobj_t *actor)
   if (!mbf21 || !actor->state->args[0])
     return;
 
-  type  = ARG_DEFAULT(actor->state->args[0], 0) - 1;
-  angle = ARG_DEFAULT(actor->state->args[1], 0);
-  ofs_x = ARG_DEFAULT(actor->state->args[2], 0);
-  ofs_y = ARG_DEFAULT(actor->state->args[3], 0);
-  ofs_z = ARG_DEFAULT(actor->state->args[4], 0);
-  vel_x = ARG_DEFAULT(actor->state->args[5], 0);
-  vel_y = ARG_DEFAULT(actor->state->args[6], 0);
-  vel_z = ARG_DEFAULT(actor->state->args[7], 0);
+  type  = actor->state->args[0] - 1;
+  angle = actor->state->args[1];
+  ofs_x = actor->state->args[2];
+  ofs_y = actor->state->args[3];
+  ofs_z = actor->state->args[4];
+  vel_x = actor->state->args[5];
+  vel_y = actor->state->args[6];
+  vel_z = actor->state->args[7];
 
   // calculate position offsets
   an = actor->angle + (unsigned int)(((int_64_t)angle << 16) / 360);
@@ -3076,11 +3076,11 @@ void A_MonsterProjectile(mobj_t *actor)
   if (!mbf21 || !actor->target || !actor->state->args[0])
     return;
 
-  type        = ARG_DEFAULT(actor->state->args[0], 0) - 1;
-  angle       = ARG_DEFAULT(actor->state->args[1], 0);
-  pitch       = ARG_DEFAULT(actor->state->args[2], 0);
-  spawnofs_xy = ARG_DEFAULT(actor->state->args[3], 0);
-  spawnofs_z  = ARG_DEFAULT(actor->state->args[4], 0);
+  type        = actor->state->args[0] - 1;
+  angle       = actor->state->args[1];
+  pitch       = actor->state->args[2];
+  spawnofs_xy = actor->state->args[3];
+  spawnofs_z  = actor->state->args[4];
 
   A_FaceTarget(actor);
   mo = P_SpawnMissile(actor, actor->target, type);
@@ -3125,11 +3125,11 @@ void A_MonsterBulletAttack(mobj_t *actor)
   if (!mbf21 || !actor->target)
     return;
 
-  hspread    = ARG_DEFAULT(actor->state->args[0], 0);
-  vspread    = ARG_DEFAULT(actor->state->args[1], 0);
-  numbullets = ARG_DEFAULT(actor->state->args[2], 1);
-  damagebase = ARG_DEFAULT(actor->state->args[3], 3);
-  damagemod  = ARG_DEFAULT(actor->state->args[4], 5);
+  hspread    = actor->state->args[0];
+  vspread    = actor->state->args[1];
+  numbullets = actor->state->args[2];
+  damagebase = actor->state->args[3];
+  damagemod  = actor->state->args[4];
 
   A_FaceTarget(actor);
   S_StartSound(actor, actor->info->attacksound);

--- a/prboom2/src/p_pspr.c
+++ b/prboom2/src/p_pspr.c
@@ -1156,11 +1156,11 @@ void A_WeaponProjectile(player_t *player, pspdef_t *psp)
   if (!mbf21 || !psp->state || !psp->state->args[0])
     return;
 
-  type        = ARG_DEFAULT(psp->state->args[0], 0) - 1;
-  angle       = ARG_DEFAULT(psp->state->args[1], 0);
-  pitch       = ARG_DEFAULT(psp->state->args[2], 0);
-  spawnofs_xy = ARG_DEFAULT(psp->state->args[3], 0);
-  spawnofs_z  = ARG_DEFAULT(psp->state->args[4], 0);
+  type        = psp->state->args[0] - 1;
+  angle       = psp->state->args[1];
+  pitch       = psp->state->args[2];
+  spawnofs_xy = psp->state->args[3];
+  spawnofs_z  = psp->state->args[4];
 
   mo = P_SpawnPlayerMissile(player->mo, type);
   if (!mo)
@@ -1202,11 +1202,11 @@ void A_WeaponBulletAttack(player_t *player, pspdef_t *psp)
   if (!mbf21 || !psp->state)
     return;
 
-  hspread    = ARG_DEFAULT(psp->state->args[0], 0);
-  vspread    = ARG_DEFAULT(psp->state->args[1], 0);
-  numbullets = ARG_DEFAULT(psp->state->args[2], 1);
-  damagebase = ARG_DEFAULT(psp->state->args[3], 5);
-  damagemod  = ARG_DEFAULT(psp->state->args[4], 3);
+  hspread    = psp->state->args[0];
+  vspread    = psp->state->args[1];
+  numbullets = psp->state->args[2];
+  damagebase = psp->state->args[3];
+  damagemod  = psp->state->args[4];
 
   P_BulletSlope(player->mo);
 


### PR DESCRIPTION
Here's an idea to move the argument default setters to the d_deh file so we can process the states once, instead of running the checks each time the function gets called.

`CheckDehConsistency` should maybe be changed to something like `PostProcessDeh` if we expand it like this.